### PR TITLE
Přidány metadata pro datové sady k ReZa

### DIFF
--- a/rpp/Identifikátory specifického omezení.jsonld
+++ b/rpp/Identifikátory specifického omezení.jsonld
@@ -55,7 +55,7 @@
   "distribuce": [
     {
       "typ": "Distribuce",
-      "iri": "https://data.dia.gov.cz/zdroj/datové-sady/rpp/orgány-veřejné-moci/distribuce/0",
+      "iri": "https://data.dia.gov.cz/zdroj/datové-sady/rpp/identifikátory-specifického-omezení/distribuce/0",
       "podmínky_užití": {
         "typ": "Specifikace podmínek užití",
         "autorské_dílo": "https://data.gov.cz/podmínky-užití/neobsahuje-autorská-díla/",
@@ -71,7 +71,7 @@
     },
     {
       "typ": "Distribuce",
-      "iri": "https://data.dia.gov.cz/zdroj/datové-sady/rpp/orgány-veřejné-moci/distribuce/1",
+      "iri": "https://data.dia.gov.cz/zdroj/datové-sady/rpp/identifikátory-specifického-omezení/distribuce/1",
       "podmínky_užití": {
         "typ": "Specifikace podmínek užití",
         "autorské_dílo": "https://data.gov.cz/podmínky-užití/neobsahuje-autorská-díla/",
@@ -87,7 +87,7 @@
     },
     {
       "typ": "Distribuce",
-      "iri": "https://data.dia.gov.cz/zdroj/datové-sady/rpp/orgány-veřejné-moci/distribuce/2",
+      "iri": "https://data.dia.gov.cz/zdroj/datové-sady/rpp/identifikátory-specifického-omezení/distribuce/2",
       "název": {
         "cs": "SPARQL Endpoint",
         "en": "SPARQL Endpoint"
@@ -104,12 +104,12 @@
         "typ": "Datová služba",
         "přístupový_bod": "https://rpp-opendata.egon.gov.cz/odrpp/sparql/",
         "popis_přístupového_bodu": "https://rpp-opendata.egon.gov.cz/odrpp/sparql/",
-        "iri": "https://data.dia.gov.cz/zdroj/datové-sady/rpp/orgány-veřejné-moci/distribuce/2/přístupová-služba",
+        "iri": "https://data.dia.gov.cz/zdroj/datové-sady/rpp/identifikátory-specifického-omezení/distribuce/2/přístupová-služba",
         "název": {
           "cs": "SPARQL Endpoint",
           "en": "SPARQL Endpoint"
         },
-        "poskytuje_datovou_sadu": "https://data.dia.gov.cz/zdroj/datové-sady/rpp/orgány-veřejné-moci",
+        "poskytuje_datovou_sadu": "https://data.dia.gov.cz/zdroj/datové-sady/rpp/identifikátory-specifického-omezení",
         "specifikace": "https://www.w3.org/TR/sparql11-protocol/"
       }
     }

--- a/rpp/Identifikátory specifického omezení.jsonld
+++ b/rpp/Identifikátory specifického omezení.jsonld
@@ -1,6 +1,6 @@
 {
   "@context": "https://ofn.gov.cz/dcat-ap-cz-rozhraní-katalogů-otevřených-dat/2024-05-28/kontexty/rozhraní-katalogů-otevřených-dat.jsonld",
-  "iri": "https://data.dia.gov.cz/zdroj/datové-sady/rpp/orgány-veřejné-moci",
+  "iri": "https://data.dia.gov.cz/zdroj/datové-sady/rpp/identifikátory-specifického-omezení",
   "typ": "Datová sada",
   "název": {
     "cs": "Identifikátory specifického omezení"

--- a/rpp/Identifikátory specifického omezení.jsonld
+++ b/rpp/Identifikátory specifického omezení.jsonld
@@ -1,0 +1,117 @@
+{
+  "@context": "https://ofn.gov.cz/dcat-ap-cz-rozhraní-katalogů-otevřených-dat/2024-05-28/kontexty/rozhraní-katalogů-otevřených-dat.jsonld",
+  "iri": "https://data.dia.gov.cz/zdroj/datové-sady/rpp/orgány-veřejné-moci",
+  "typ": "Datová sada",
+  "název": {
+    "cs": "Identifikátory specifického omezení"
+  },
+  "popis": {
+    "cs": "Identifikátory specifického omezení používané v šabloně oprávnění k zastupování evidované v Registru práv a povinností ve smyslu § 52 zákona č. 111/2009 Sb. o základních registrech."
+  },
+  "prvek_rúian": [
+    "https://linked.cuzk.cz/resource/ruian/stat/1"
+  ],
+  "geografické_území": [],
+  "prostorové_pokrytí": [],
+  "klíčové_slovo": {
+    "cs": [
+      "registr práv a povinností",
+      "rpp",
+      "ReZa",
+      "registr zastupování"
+    ],
+    "en": []
+  },
+  "periodicita_aktualizace": "http://publications.europa.eu/resource/authority/frequency/DAILY",
+  "dokumentace": "https://ofn.gov.cz/registr-práv-a-povinností/identifikátor-specifického-omezení/2026-05-18/",
+  "téma": [
+    "http://publications.europa.eu/resource/authority/data-theme/GOVE"
+  ],
+  "koncept_euroVoc": [
+    "http://eurovoc.europa.eu/77",
+    "http://eurovoc.europa.eu/4136",
+    "http://eurovoc.europa.eu/39",
+    "http://eurovoc.europa.eu/4182",
+    "http://eurovoc.europa.eu/3062",
+    "http://eurovoc.europa.eu/2584",
+    "http://eurovoc.europa.eu/68",
+    "http://eurovoc.europa.eu/5120",
+    "http://eurovoc.europa.eu/2588",
+    "http://eurovoc.europa.eu/6897",
+    "http://eurovoc.europa.eu/4272",
+    "http://eurovoc.europa.eu/6609"
+  ],
+  "specifikace": [
+    "https://ofn.gov.cz/registr-práv-a-povinností/identifikátor-specifického-omezení/2026-05-18/"
+  ],
+  "kontaktní_bod": {
+    "typ": "Organizace",
+    "jméno": {
+      "cs": "Help desk Digitální a informační agentury (DIA)"
+    },
+    "e-mail": "mailto:podpora@dia.gov.cz"
+  },
+  "poskytovatel": "https://rpp-opendata.egon.gov.cz/odrpp/zdroj/orgán-veřejné-moci/17651921",
+  "distribuce": [
+    {
+      "typ": "Distribuce",
+      "iri": "https://data.dia.gov.cz/zdroj/datové-sady/rpp/orgány-veřejné-moci/distribuce/0",
+      "podmínky_užití": {
+        "typ": "Specifikace podmínek užití",
+        "autorské_dílo": "https://data.gov.cz/podmínky-užití/neobsahuje-autorská-díla/",
+        "databáze_jako_autorské_dílo": "https://data.gov.cz/podmínky-užití/není-autorskoprávně-chráněnou-databází/",
+        "databáze_chráněná_zvláštními_právy": "https://data.gov.cz/podmínky-užití/není-chráněna-zvláštním-právem-pořizovatele-databáze/",
+        "osobní_údaje": "https://data.gov.cz/podmínky-užití/neobsahuje-osobní-údaje/"
+      },
+      "soubor_ke_stažení": "https://rpp-opendata.egon.gov.cz/odrpp/datovasada/reza_identifikator_specifickeho_omezeni.json",
+      "přístupové_url": "https://rpp-opendata.egon.gov.cz/odrpp/datovasada/reza_identifikator_specifickeho_omezeni.json",
+      "typ_média": "http://www.iana.org/assignments/media-types/application/json",
+      "formát": "http://publications.europa.eu/resource/authority/file-type/JSON",
+      "schéma": "https://ofn.gov.cz/registr-práv-a-povinností/identifikátor-specifického-omezení/2026-05-18/identifikator-specifickeho-omezeni_schema.json"
+    },
+    {
+      "typ": "Distribuce",
+      "iri": "https://data.dia.gov.cz/zdroj/datové-sady/rpp/orgány-veřejné-moci/distribuce/1",
+      "podmínky_užití": {
+        "typ": "Specifikace podmínek užití",
+        "autorské_dílo": "https://data.gov.cz/podmínky-užití/neobsahuje-autorská-díla/",
+        "databáze_jako_autorské_dílo": "https://data.gov.cz/podmínky-užití/není-autorskoprávně-chráněnou-databází/",
+        "databáze_chráněná_zvláštními_právy": "https://data.gov.cz/podmínky-užití/není-chráněna-zvláštním-právem-pořizovatele-databáze/",
+        "osobní_údaje": "https://data.gov.cz/podmínky-užití/neobsahuje-osobní-údaje/"
+      },
+      "soubor_ke_stažení": "https://rpp-opendata.egon.gov.cz/odrpp/datovasada/reza_identifikator_specifickeho_omezeni.jsonld",
+      "přístupové_url": "https://rpp-opendata.egon.gov.cz/odrpp/datovasada/reza_identifikator_specifickeho_omezeni.jsonld",
+      "typ_média": "http://www.iana.org/assignments/media-types/application/ld+json",
+      "formát": "http://publications.europa.eu/resource/authority/file-type/JSON_LD",
+      "schéma": "https://ofn.gov.cz/registr-práv-a-povinností/identifikátor-specifického-omezení/2026-05-18/identifikator-specifickeho-omezeni_schema.json"
+    },
+    {
+      "typ": "Distribuce",
+      "iri": "https://data.dia.gov.cz/zdroj/datové-sady/rpp/orgány-veřejné-moci/distribuce/2",
+      "název": {
+        "cs": "SPARQL Endpoint",
+        "en": "SPARQL Endpoint"
+      },
+      "podmínky_užití": {
+        "typ": "Specifikace podmínek užití",
+        "autorské_dílo": "https://data.gov.cz/podmínky-užití/neobsahuje-autorská-díla/",
+        "databáze_jako_autorské_dílo": "https://data.gov.cz/podmínky-užití/není-autorskoprávně-chráněnou-databází/",
+        "databáze_chráněná_zvláštními_právy": "https://data.gov.cz/podmínky-užití/není-chráněna-zvláštním-právem-pořizovatele-databáze/",
+        "osobní_údaje": "https://data.gov.cz/podmínky-užití/neobsahuje-osobní-údaje/"
+      },
+      "přístupové_url": "https://rpp-opendata.egon.gov.cz/odrpp/sparql/",
+      "přístupová_služba": {
+        "typ": "Datová služba",
+        "přístupový_bod": "https://rpp-opendata.egon.gov.cz/odrpp/sparql/",
+        "popis_přístupového_bodu": "https://rpp-opendata.egon.gov.cz/odrpp/sparql/",
+        "iri": "https://data.dia.gov.cz/zdroj/datové-sady/rpp/orgány-veřejné-moci/distribuce/2/přístupová-služba",
+        "název": {
+          "cs": "SPARQL Endpoint",
+          "en": "SPARQL Endpoint"
+        },
+        "poskytuje_datovou_sadu": "https://data.dia.gov.cz/zdroj/datové-sady/rpp/orgány-veřejné-moci",
+        "specifikace": "https://www.w3.org/TR/sparql11-protocol/"
+      }
+    }
+  ]
+}

--- a/rpp/Objekty šablony k zastupování.jsonld
+++ b/rpp/Objekty šablony k zastupování.jsonld
@@ -55,7 +55,7 @@
   "distribuce": [
     {
       "typ": "Distribuce",
-      "iri": "https://data.dia.gov.cz/zdroj/datové-sady/rpp/orgány-veřejné-moci/distribuce/0",
+      "iri": "https://data.dia.gov.cz/zdroj/datové-sady/rpp/objekty-šablony-k-zastupování/distribuce/0",
       "podmínky_užití": {
         "typ": "Specifikace podmínek užití",
         "autorské_dílo": "https://data.gov.cz/podmínky-užití/neobsahuje-autorská-díla/",
@@ -71,7 +71,7 @@
     },
     {
       "typ": "Distribuce",
-      "iri": "https://data.dia.gov.cz/zdroj/datové-sady/rpp/orgány-veřejné-moci/distribuce/1",
+      "iri": "https://data.dia.gov.cz/zdroj/datové-sady/rpp/objekty-šablony-k-zastupování/distribuce/1",
       "podmínky_užití": {
         "typ": "Specifikace podmínek užití",
         "autorské_dílo": "https://data.gov.cz/podmínky-užití/neobsahuje-autorská-díla/",
@@ -87,7 +87,7 @@
     },
     {
       "typ": "Distribuce",
-      "iri": "https://data.dia.gov.cz/zdroj/datové-sady/rpp/orgány-veřejné-moci/distribuce/2",
+      "iri": "https://data.dia.gov.cz/zdroj/datové-sady/rpp/objekty-šablony-k-zastupování/distribuce/2",
       "název": {
         "cs": "SPARQL Endpoint",
         "en": "SPARQL Endpoint"
@@ -104,12 +104,12 @@
         "typ": "Datová služba",
         "přístupový_bod": "https://rpp-opendata.egon.gov.cz/odrpp/sparql/",
         "popis_přístupového_bodu": "https://rpp-opendata.egon.gov.cz/odrpp/sparql/",
-        "iri": "https://data.dia.gov.cz/zdroj/datové-sady/rpp/orgány-veřejné-moci/distribuce/2/přístupová-služba",
+        "iri": "https://data.dia.gov.cz/zdroj/datové-sady/rpp/objekty-šablony-k-zastupování/distribuce/2/přístupová-služba",
         "název": {
           "cs": "SPARQL Endpoint",
           "en": "SPARQL Endpoint"
         },
-        "poskytuje_datovou_sadu": "https://data.dia.gov.cz/zdroj/datové-sady/rpp/orgány-veřejné-moci",
+        "poskytuje_datovou_sadu": "https://data.dia.gov.cz/zdroj/datové-sady/rpp/objekty-šablony-k-zastupování",
         "specifikace": "https://www.w3.org/TR/sparql11-protocol/"
       }
     }

--- a/rpp/Objekty šablony k zastupování.jsonld
+++ b/rpp/Objekty šablony k zastupování.jsonld
@@ -1,0 +1,117 @@
+{
+  "@context": "https://ofn.gov.cz/dcat-ap-cz-rozhraní-katalogů-otevřených-dat/2024-05-28/kontexty/rozhraní-katalogů-otevřených-dat.jsonld",
+  "iri": "https://data.dia.gov.cz/zdroj/datové-sady/rpp/orgány-veřejné-moci",
+  "typ": "Datová sada",
+  "název": {
+    "cs": "Objekty šablony k zastupování"
+  },
+  "popis": {
+    "cs": "Objekty šablony k zastupování používané v šabloně oprávnění k zastupování evidované v Registru práv a povinností ve smyslu § 52 zákona č. 111/2009 Sb. o základních registrech."
+  },
+  "prvek_rúian": [
+    "https://linked.cuzk.cz/resource/ruian/stat/1"
+  ],
+  "geografické_území": [],
+  "prostorové_pokrytí": [],
+  "klíčové_slovo": {
+    "cs": [
+      "registr práv a povinností",
+      "rpp",
+      "ReZa",
+      "registr zastupování"
+    ],
+    "en": []
+  },
+  "periodicita_aktualizace": "http://publications.europa.eu/resource/authority/frequency/DAILY",
+  "dokumentace": "https://ofn.gov.cz/registr-práv-a-povinností/objekt-šablony/2026-05-18/",
+  "téma": [
+    "http://publications.europa.eu/resource/authority/data-theme/GOVE"
+  ],
+  "koncept_euroVoc": [
+    "http://eurovoc.europa.eu/77",
+    "http://eurovoc.europa.eu/4136",
+    "http://eurovoc.europa.eu/39",
+    "http://eurovoc.europa.eu/4182",
+    "http://eurovoc.europa.eu/3062",
+    "http://eurovoc.europa.eu/2584",
+    "http://eurovoc.europa.eu/68",
+    "http://eurovoc.europa.eu/5120",
+    "http://eurovoc.europa.eu/2588",
+    "http://eurovoc.europa.eu/6897",
+    "http://eurovoc.europa.eu/4272",
+    "http://eurovoc.europa.eu/6609"
+  ],
+  "specifikace": [
+    "https://ofn.gov.cz/registr-práv-a-povinností/objekt-šablony/2026-05-18/"
+  ],
+  "kontaktní_bod": {
+    "typ": "Organizace",
+    "jméno": {
+      "cs": "Help desk Digitální a informační agentury (DIA)"
+    },
+    "e-mail": "mailto:podpora@dia.gov.cz"
+  },
+  "poskytovatel": "https://rpp-opendata.egon.gov.cz/odrpp/zdroj/orgán-veřejné-moci/17651921",
+  "distribuce": [
+    {
+      "typ": "Distribuce",
+      "iri": "https://data.dia.gov.cz/zdroj/datové-sady/rpp/orgány-veřejné-moci/distribuce/0",
+      "podmínky_užití": {
+        "typ": "Specifikace podmínek užití",
+        "autorské_dílo": "https://data.gov.cz/podmínky-užití/neobsahuje-autorská-díla/",
+        "databáze_jako_autorské_dílo": "https://data.gov.cz/podmínky-užití/není-autorskoprávně-chráněnou-databází/",
+        "databáze_chráněná_zvláštními_právy": "https://data.gov.cz/podmínky-užití/není-chráněna-zvláštním-právem-pořizovatele-databáze/",
+        "osobní_údaje": "https://data.gov.cz/podmínky-užití/neobsahuje-osobní-údaje/"
+      },
+      "soubor_ke_stažení": "https://rpp-opendata.egon.gov.cz/odrpp/datovasada/reza_objekt_sablony.json",
+      "přístupové_url": "https://rpp-opendata.egon.gov.cz/odrpp/datovasada/reza_objekt_sablony.json",
+      "typ_média": "http://www.iana.org/assignments/media-types/application/json",
+      "formát": "http://publications.europa.eu/resource/authority/file-type/JSON",
+      "schéma": "https://ofn.gov.cz/registr-práv-a-povinností/objekt-šablony/2026-05-18/objekt-šablony_schema.json"
+    },
+    {
+      "typ": "Distribuce",
+      "iri": "https://data.dia.gov.cz/zdroj/datové-sady/rpp/orgány-veřejné-moci/distribuce/1",
+      "podmínky_užití": {
+        "typ": "Specifikace podmínek užití",
+        "autorské_dílo": "https://data.gov.cz/podmínky-užití/neobsahuje-autorská-díla/",
+        "databáze_jako_autorské_dílo": "https://data.gov.cz/podmínky-užití/není-autorskoprávně-chráněnou-databází/",
+        "databáze_chráněná_zvláštními_právy": "https://data.gov.cz/podmínky-užití/není-chráněna-zvláštním-právem-pořizovatele-databáze/",
+        "osobní_údaje": "https://data.gov.cz/podmínky-užití/neobsahuje-osobní-údaje/"
+      },
+      "soubor_ke_stažení": "https://rpp-opendata.egon.gov.cz/odrpp/datovasada/reza_objekt_sablony.jsonld",
+      "přístupové_url": "https://rpp-opendata.egon.gov.cz/odrpp/datovasada/reza_objekt_sablony.jsonld",
+      "typ_média": "http://www.iana.org/assignments/media-types/application/ld+json",
+      "formát": "http://publications.europa.eu/resource/authority/file-type/JSON_LD",
+      "schéma": "https://ofn.gov.cz/registr-práv-a-povinností/objekt-šablony/2026-05-18/objekt-šablony_schema.json"
+    },
+    {
+      "typ": "Distribuce",
+      "iri": "https://data.dia.gov.cz/zdroj/datové-sady/rpp/orgány-veřejné-moci/distribuce/2",
+      "název": {
+        "cs": "SPARQL Endpoint",
+        "en": "SPARQL Endpoint"
+      },
+      "podmínky_užití": {
+        "typ": "Specifikace podmínek užití",
+        "autorské_dílo": "https://data.gov.cz/podmínky-užití/neobsahuje-autorská-díla/",
+        "databáze_jako_autorské_dílo": "https://data.gov.cz/podmínky-užití/není-autorskoprávně-chráněnou-databází/",
+        "databáze_chráněná_zvláštními_právy": "https://data.gov.cz/podmínky-užití/není-chráněna-zvláštním-právem-pořizovatele-databáze/",
+        "osobní_údaje": "https://data.gov.cz/podmínky-užití/neobsahuje-osobní-údaje/"
+      },
+      "přístupové_url": "https://rpp-opendata.egon.gov.cz/odrpp/sparql/",
+      "přístupová_služba": {
+        "typ": "Datová služba",
+        "přístupový_bod": "https://rpp-opendata.egon.gov.cz/odrpp/sparql/",
+        "popis_přístupového_bodu": "https://rpp-opendata.egon.gov.cz/odrpp/sparql/",
+        "iri": "https://data.dia.gov.cz/zdroj/datové-sady/rpp/orgány-veřejné-moci/distribuce/2/přístupová-služba",
+        "název": {
+          "cs": "SPARQL Endpoint",
+          "en": "SPARQL Endpoint"
+        },
+        "poskytuje_datovou_sadu": "https://data.dia.gov.cz/zdroj/datové-sady/rpp/orgány-veřejné-moci",
+        "specifikace": "https://www.w3.org/TR/sparql11-protocol/"
+      }
+    }
+  ]
+}

--- a/rpp/Objekty šablony k zastupování.jsonld
+++ b/rpp/Objekty šablony k zastupování.jsonld
@@ -1,6 +1,6 @@
 {
   "@context": "https://ofn.gov.cz/dcat-ap-cz-rozhraní-katalogů-otevřených-dat/2024-05-28/kontexty/rozhraní-katalogů-otevřených-dat.jsonld",
-  "iri": "https://data.dia.gov.cz/zdroj/datové-sady/rpp/orgány-veřejné-moci",
+  "iri": "https://data.dia.gov.cz/zdroj/datové-sady/rpp/objekty-šablony-k-zastupování",
   "typ": "Datová sada",
   "název": {
     "cs": "Objekty šablony k zastupování"

--- a/rpp/Číselník rolí zastupování.jsonld
+++ b/rpp/Číselník rolí zastupování.jsonld
@@ -1,6 +1,6 @@
 {
   "@context": "https://ofn.gov.cz/dcat-ap-cz-rozhraní-katalogů-otevřených-dat/2024-05-28/kontexty/rozhraní-katalogů-otevřených-dat.jsonld",
-  "iri": "https://data.dia.gov.cz/zdroj/datové-sady/rpp/číselník-fází",
+  "iri": "https://data.dia.gov.cz/zdroj/datové-sady/rpp/číselník-rolí-zastupování",
   "typ": "Datová sada",
   "název": {
     "cs": "Číselník rolí zastupování"

--- a/rpp/Číselník rolí zastupování.jsonld
+++ b/rpp/Číselník rolí zastupování.jsonld
@@ -1,0 +1,70 @@
+{
+  "@context": "https://ofn.gov.cz/dcat-ap-cz-rozhraní-katalogů-otevřených-dat/2024-05-28/kontexty/rozhraní-katalogů-otevřených-dat.jsonld",
+  "iri": "https://data.dia.gov.cz/zdroj/datové-sady/rpp/číselník-fází",
+  "typ": "Datová sada",
+  "název": {
+    "cs": "Číselník rolí zastupování"
+  },
+  "popis": {
+    "cs": "Číselník rolí zastupování se používá pro kódování jednotlivých rolí zastupovaného a zastupujícího v Registru zastupování. Číselník je použit v datové sadě Šablony oprávnění k zastupování."
+  },
+  "prvek_rúian": [
+    "https://linked.cuzk.cz/resource/ruian/stat/1"
+  ],
+  "geografické_území": [],
+  "prostorové_pokrytí": [],
+  "klíčové_slovo": {
+    "cs": [
+      "rpp",
+      "registr práv a povinností",
+      "číselník",
+      "ReZa",
+      "Registr zastupování"
+    ],
+    "en": []
+  },
+  "periodicita_aktualizace": "http://publications.europa.eu/resource/authority/frequency/DAILY",
+  "téma": [
+    "http://publications.europa.eu/resource/authority/data-theme/GOVE"
+  ],
+  "koncept_euroVoc": [],
+  "kontaktní_bod": {
+    "typ": "Organizace",
+    "jméno": {
+      "cs": "Šimon Trusina"
+    }
+  },
+  "poskytovatel": "https://rpp-opendata.egon.gov.cz/odrpp/zdroj/orgán-veřejné-moci/17651921",
+  "distribuce": [
+    {
+      "typ": "Distribuce",
+      "iri": "https://data.dia.gov.cz/zdroj/datové-sady/rpp/číselník-fází/distribuce/0",
+      "podmínky_užití": {
+        "typ": "Specifikace podmínek užití",
+        "autorské_dílo": "https://data.gov.cz/podmínky-užití/neobsahuje-autorská-díla/",
+        "databáze_jako_autorské_dílo": "https://data.gov.cz/podmínky-užití/není-autorskoprávně-chráněnou-databází/",
+        "databáze_chráněná_zvláštními_právy": "https://data.gov.cz/podmínky-užití/není-chráněna-zvláštním-právem-pořizovatele-databáze/",
+        "osobní_údaje": "https://data.gov.cz/podmínky-užití/neobsahuje-osobní-údaje/"
+      },
+      "soubor_ke_stažení": "https://rpp-opendata.egon.gov.cz/odrpp/datovasada/reza_role_zastupovani.json",
+      "přístupové_url": "https://rpp-opendata.egon.gov.cz/odrpp/datovasada/reza_role_zastupovani.json",
+      "typ_média": "http://www.iana.org/assignments/media-types/application/json",
+      "formát": "http://publications.europa.eu/resource/authority/file-type/JSON"
+    },
+    {
+      "typ": "Distribuce",
+      "iri": "https://data.dia.gov.cz/zdroj/datové-sady/rpp/číselník-fází/distribuce/1",
+      "podmínky_užití": {
+        "typ": "Specifikace podmínek užití",
+        "autorské_dílo": "https://data.gov.cz/podmínky-užití/neobsahuje-autorská-díla/",
+        "databáze_jako_autorské_dílo": "https://data.gov.cz/podmínky-užití/není-autorskoprávně-chráněnou-databází/",
+        "databáze_chráněná_zvláštními_právy": "https://data.gov.cz/podmínky-užití/není-chráněna-zvláštním-právem-pořizovatele-databáze/",
+        "osobní_údaje": "https://data.gov.cz/podmínky-užití/neobsahuje-osobní-údaje/"
+      },
+      "soubor_ke_stažení": "https://rpp-opendata.egon.gov.cz/odrpp/datovasada/reza_role_zastupovani.jsonld",
+      "přístupové_url": "https://rpp-opendata.egon.gov.cz/odrpp/datovasada/reza_role_zastupovani.jsonld",
+      "typ_média": "http://www.iana.org/assignments/media-types/application/ld+json",
+      "formát": "http://publications.europa.eu/resource/authority/file-type/JSON_LD"
+    }
+  ]
+}

--- a/rpp/Šablony oprávnění k zastupování.jsonld
+++ b/rpp/Šablony oprávnění k zastupování.jsonld
@@ -55,7 +55,7 @@
   "distribuce": [
     {
       "typ": "Distribuce",
-      "iri": "https://data.dia.gov.cz/zdroj/datové-sady/rpp/orgány-veřejné-moci/distribuce/0",
+      "iri": "https://data.dia.gov.cz/zdroj/datové-sady/rpp/šablony-okz/distribuce/0",
       "podmínky_užití": {
         "typ": "Specifikace podmínek užití",
         "autorské_dílo": "https://data.gov.cz/podmínky-užití/neobsahuje-autorská-díla/",
@@ -71,7 +71,7 @@
     },
     {
       "typ": "Distribuce",
-      "iri": "https://data.dia.gov.cz/zdroj/datové-sady/rpp/orgány-veřejné-moci/distribuce/1",
+      "iri": "https://data.dia.gov.cz/zdroj/datové-sady/rpp/šablony-okz/distribuce/1",
       "podmínky_užití": {
         "typ": "Specifikace podmínek užití",
         "autorské_dílo": "https://data.gov.cz/podmínky-užití/neobsahuje-autorská-díla/",
@@ -87,7 +87,7 @@
     },
     {
       "typ": "Distribuce",
-      "iri": "https://data.dia.gov.cz/zdroj/datové-sady/rpp/orgány-veřejné-moci/distribuce/2",
+      "iri": "https://data.dia.gov.cz/zdroj/datové-sady/rpp/šablony-okz/distribuce/2",
       "název": {
         "cs": "SPARQL Endpoint",
         "en": "SPARQL Endpoint"
@@ -104,12 +104,12 @@
         "typ": "Datová služba",
         "přístupový_bod": "https://rpp-opendata.egon.gov.cz/odrpp/sparql/",
         "popis_přístupového_bodu": "https://rpp-opendata.egon.gov.cz/odrpp/sparql/",
-        "iri": "https://data.dia.gov.cz/zdroj/datové-sady/rpp/orgány-veřejné-moci/distribuce/2/přístupová-služba",
+        "iri": "https://data.dia.gov.cz/zdroj/datové-sady/rpp/šablony-okz/distribuce/2/přístupová-služba",
         "název": {
           "cs": "SPARQL Endpoint",
           "en": "SPARQL Endpoint"
         },
-        "poskytuje_datovou_sadu": "https://data.dia.gov.cz/zdroj/datové-sady/rpp/orgány-veřejné-moci",
+        "poskytuje_datovou_sadu": "https://data.dia.gov.cz/zdroj/datové-sady/rpp/šablony-okz",
         "specifikace": "https://www.w3.org/TR/sparql11-protocol/"
       }
     }

--- a/rpp/Šablony oprávnění k zastupování.jsonld
+++ b/rpp/Šablony oprávnění k zastupování.jsonld
@@ -1,6 +1,6 @@
 {
   "@context": "https://ofn.gov.cz/dcat-ap-cz-rozhraní-katalogů-otevřených-dat/2024-05-28/kontexty/rozhraní-katalogů-otevřených-dat.jsonld",
-  "iri": "https://data.dia.gov.cz/zdroj/datové-sady/rpp/orgány-veřejné-moci",
+  "iri": "https://data.dia.gov.cz/zdroj/datové-sady/rpp/šablony-okz",
   "typ": "Datová sada",
   "název": {
     "cs": "Šablony oprávnění k zastupování"

--- a/rpp/Šablony oprávnění k zastupování.jsonld
+++ b/rpp/Šablony oprávnění k zastupování.jsonld
@@ -1,0 +1,117 @@
+{
+  "@context": "https://ofn.gov.cz/dcat-ap-cz-rozhraní-katalogů-otevřených-dat/2024-05-28/kontexty/rozhraní-katalogů-otevřených-dat.jsonld",
+  "iri": "https://data.dia.gov.cz/zdroj/datové-sady/rpp/orgány-veřejné-moci",
+  "typ": "Datová sada",
+  "název": {
+    "cs": "Šablony oprávnění k zastupování"
+  },
+  "popis": {
+    "cs": "Šablony oprávnění k zastupování používané v šabloně oprávnění k zastupování evidované v Registru práv a povinností ve smyslu § 52 zákona č. 111/2009 Sb. o základních registrech."
+  },
+  "prvek_rúian": [
+    "https://linked.cuzk.cz/resource/ruian/stat/1"
+  ],
+  "geografické_území": [],
+  "prostorové_pokrytí": [],
+  "klíčové_slovo": {
+    "cs": [
+      "registr práv a povinností",
+      "rpp",
+      "ReZa",
+      "registr zastupování"
+    ],
+    "en": []
+  },
+  "periodicita_aktualizace": "http://publications.europa.eu/resource/authority/frequency/DAILY",
+  "dokumentace": "https://ofn.gov.cz/registr-práv-a-povinností/šablona-okz/2026-05-18/",
+  "téma": [
+    "http://publications.europa.eu/resource/authority/data-theme/GOVE"
+  ],
+  "koncept_euroVoc": [
+    "http://eurovoc.europa.eu/77",
+    "http://eurovoc.europa.eu/4136",
+    "http://eurovoc.europa.eu/39",
+    "http://eurovoc.europa.eu/4182",
+    "http://eurovoc.europa.eu/3062",
+    "http://eurovoc.europa.eu/2584",
+    "http://eurovoc.europa.eu/68",
+    "http://eurovoc.europa.eu/5120",
+    "http://eurovoc.europa.eu/2588",
+    "http://eurovoc.europa.eu/6897",
+    "http://eurovoc.europa.eu/4272",
+    "http://eurovoc.europa.eu/6609"
+  ],
+  "specifikace": [
+    "https://ofn.gov.cz/registr-práv-a-povinností/šablona-okz/2026-05-18/"
+  ],
+  "kontaktní_bod": {
+    "typ": "Organizace",
+    "jméno": {
+      "cs": "Help desk Digitální a informační agentury (DIA)"
+    },
+    "e-mail": "mailto:podpora@dia.gov.cz"
+  },
+  "poskytovatel": "https://rpp-opendata.egon.gov.cz/odrpp/zdroj/orgán-veřejné-moci/17651921",
+  "distribuce": [
+    {
+      "typ": "Distribuce",
+      "iri": "https://data.dia.gov.cz/zdroj/datové-sady/rpp/orgány-veřejné-moci/distribuce/0",
+      "podmínky_užití": {
+        "typ": "Specifikace podmínek užití",
+        "autorské_dílo": "https://data.gov.cz/podmínky-užití/neobsahuje-autorská-díla/",
+        "databáze_jako_autorské_dílo": "https://data.gov.cz/podmínky-užití/není-autorskoprávně-chráněnou-databází/",
+        "databáze_chráněná_zvláštními_právy": "https://data.gov.cz/podmínky-užití/není-chráněna-zvláštním-právem-pořizovatele-databáze/",
+        "osobní_údaje": "https://data.gov.cz/podmínky-užití/neobsahuje-osobní-údaje/"
+      },
+      "soubor_ke_stažení": "https://rpp-opendata.egon.gov.cz/odrpp/datovasada/reza_sablona_okz.json",
+      "přístupové_url": "https://rpp-opendata.egon.gov.cz/odrpp/datovasada/reza_sablona_okz.json",
+      "typ_média": "http://www.iana.org/assignments/media-types/application/json",
+      "formát": "http://publications.europa.eu/resource/authority/file-type/JSON",
+      "schéma": "https://ofn.gov.cz/registr-práv-a-povinností/šablona-okz/2026-05-18/šablona-okz_schema.json"
+    },
+    {
+      "typ": "Distribuce",
+      "iri": "https://data.dia.gov.cz/zdroj/datové-sady/rpp/orgány-veřejné-moci/distribuce/1",
+      "podmínky_užití": {
+        "typ": "Specifikace podmínek užití",
+        "autorské_dílo": "https://data.gov.cz/podmínky-užití/neobsahuje-autorská-díla/",
+        "databáze_jako_autorské_dílo": "https://data.gov.cz/podmínky-užití/není-autorskoprávně-chráněnou-databází/",
+        "databáze_chráněná_zvláštními_právy": "https://data.gov.cz/podmínky-užití/není-chráněna-zvláštním-právem-pořizovatele-databáze/",
+        "osobní_údaje": "https://data.gov.cz/podmínky-užití/neobsahuje-osobní-údaje/"
+      },
+      "soubor_ke_stažení": "https://rpp-opendata.egon.gov.cz/odrpp/datovasada/reza_sablona_okz.jsonld",
+      "přístupové_url": "https://rpp-opendata.egon.gov.cz/odrpp/datovasada/reza_sablona_okz.jsonld",
+      "typ_média": "http://www.iana.org/assignments/media-types/application/ld+json",
+      "formát": "http://publications.europa.eu/resource/authority/file-type/JSON_LD",
+      "schéma": "https://ofn.gov.cz/registr-práv-a-povinností/šablona-okz/2026-05-18/šablona-okz_schema.json"
+    },
+    {
+      "typ": "Distribuce",
+      "iri": "https://data.dia.gov.cz/zdroj/datové-sady/rpp/orgány-veřejné-moci/distribuce/2",
+      "název": {
+        "cs": "SPARQL Endpoint",
+        "en": "SPARQL Endpoint"
+      },
+      "podmínky_užití": {
+        "typ": "Specifikace podmínek užití",
+        "autorské_dílo": "https://data.gov.cz/podmínky-užití/neobsahuje-autorská-díla/",
+        "databáze_jako_autorské_dílo": "https://data.gov.cz/podmínky-užití/není-autorskoprávně-chráněnou-databází/",
+        "databáze_chráněná_zvláštními_právy": "https://data.gov.cz/podmínky-užití/není-chráněna-zvláštním-právem-pořizovatele-databáze/",
+        "osobní_údaje": "https://data.gov.cz/podmínky-užití/neobsahuje-osobní-údaje/"
+      },
+      "přístupové_url": "https://rpp-opendata.egon.gov.cz/odrpp/sparql/",
+      "přístupová_služba": {
+        "typ": "Datová služba",
+        "přístupový_bod": "https://rpp-opendata.egon.gov.cz/odrpp/sparql/",
+        "popis_přístupového_bodu": "https://rpp-opendata.egon.gov.cz/odrpp/sparql/",
+        "iri": "https://data.dia.gov.cz/zdroj/datové-sady/rpp/orgány-veřejné-moci/distribuce/2/přístupová-služba",
+        "název": {
+          "cs": "SPARQL Endpoint",
+          "en": "SPARQL Endpoint"
+        },
+        "poskytuje_datovou_sadu": "https://data.dia.gov.cz/zdroj/datové-sady/rpp/orgány-veřejné-moci",
+        "specifikace": "https://www.w3.org/TR/sparql11-protocol/"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Přidány záznamy pro nové datové sady z Rezustru zastupování:

- Číselník rolí zastupování
- Šablony oprávnění k zastupování
- Objekty šablony k zastupování
- Identifikátory specifického omezení